### PR TITLE
docs: refine MVP plan and add IaC/CICD bootstrap with issue breakdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+./.github/copilot-instructions.md

--- a/docs/plan/2026-02-09-iac-cicd-bootstrap-and-github-actions.md
+++ b/docs/plan/2026-02-09-iac-cicd-bootstrap-and-github-actions.md
@@ -1,0 +1,133 @@
+# 計画: bootstrap 以外を GitHub Actions CI でデプロイするための IaC 拡張
+
+対象計画:
+- `docs/plan/2026-02-09-mvp-rss-to-s3-to-github-discussion.md`
+- `docs/plan/2026-02-09-mvp-issue-breakdown.md`
+
+## 目的
+- 手元実行は `cdk bootstrap` のみに限定する
+- 以降のデプロイ（`cdk synth/deploy`）は GitHub Actions から実行する
+- 可能な限り設定をコード管理し、手作業を最小化する
+
+## 必要なもの（チェックリスト）
+
+### A. ローカルで一度だけ実施するもの
+- AWS アカウント/リージョンの確定（dev/prod を分ける場合は両方）
+- CDK bootstrap 実行
+  - 可能なら bootstrap テンプレートをリポジトリ管理し、`--template` で適用
+  - 例: `cdk bootstrap aws://<account-id>/<region>`
+
+### B. GitHub 側の準備
+- GitHub Actions workflow ファイル
+  - `ci.yml`（lint/test/synth）
+  - `deploy.yml`（OIDC で AWS AssumeRole → `cdk deploy`）
+- Environment（例: `dev`, `prod`）と保護ルール
+  - 必要なら手動承認を必須化
+- Repository Variables / Secrets（最小）
+  - `AWS_ACCOUNT_ID`
+  - `AWS_REGION`
+  - `AWS_ROLE_TO_ASSUME`（OIDC 先 Role ARN）
+  - `CDK_APP_CMD`（必要なら）
+
+### C. AWS 側の準備（GitHub OIDC）
+- IAM OIDC Provider: `token.actions.githubusercontent.com`
+- GitHub Actions 用 IAM Role（例: `GitHubActionsCdkDeployRole`）
+  - 信頼ポリシー条件:
+    - `aud == sts.amazonaws.com`
+    - `sub == repo:<org>/<repo>:ref:refs/heads/<branch>` など
+  - 権限:
+    - 最小は `cdk deploy` 実行に必要な権限
+    - 運用初期は管理しやすさ優先で広め、後で絞る運用でも可
+- CloudTrail / CloudWatch Logs で AssumeRole 監査可能にする
+
+### D. リポジトリで IaC 化するもの
+- `cdk.json` / `bin/` / `lib/` の CDK エントリポイント
+- bootstrap 設定値（qualifier, toolkit stack 名）をドキュメント化
+- IAM ポリシーのコード化（Lambda 実行ロール、State Machine ロール等）
+- SSM Parameter / Secrets 参照名の固定化（値の投入手順も Runbook 化）
+
+## 既存 Issue への差し込みタスク
+
+### CI-1（#1 の直後に追加）
+- タイトル案: `デプロイ戦略を固定する（local bootstrap + CI deploy）`
+- 目的:
+  - どのブランチ/環境で自動デプロイするかを先に固定し、IAM 条件に反映する
+- 受け入れ条件:
+  - 対象ブランチ、対象環境、ロール命名、リージョンが文書化されている
+
+### CI-2（#2 の前に追加）
+- タイトル案: `CDK bootstrap方式を確定しテンプレート化する`
+- 目的:
+  - bootstrap を再現可能にする（手元実行はこの手順だけ）
+- スコープ:
+  - `cdk bootstrap` コマンドとオプション（必要なら `--template`）を確定
+  - 実行結果（Toolkit スタック名、qualifier）を記録
+- 受け入れ条件:
+  - 新規環境で同一手順により bootstrap できる
+
+### CI-3（#2 の直後に追加）
+- タイトル案: `GitHub OIDC Roleを準備する`
+- 目的:
+  - GitHub Actions から長期鍵なしで AWS にデプロイ可能にする
+- スコープ:
+  - OIDC Provider / IAM Role / Trust policy / Permission policy
+  - `sub` 条件をリポジトリ・ブランチ・Environment に制限
+- 受け入れ条件:
+  - GitHub Actions で `aws sts get-caller-identity` が成功する
+
+### CI-4（#2 の直後に追加、CI-3 依存）
+- タイトル案: `GitHub ActionsのCI workflowを実装する`
+- 目的:
+  - PR 時に品質ゲート（lint/test/synth）を実施する
+- 受け入れ条件:
+  - PR で workflow が実行され、失敗時は merge できない設定が可能
+
+### CI-5（#7 の前に追加、CI-3/CI-4 依存）
+- タイトル案: `GitHub Actionsのdeploy workflowを実装する`
+- 目的:
+  - main 反映時に AWS へ自動デプロイする
+- スコープ:
+  - OIDC AssumeRole
+  - `cdk deploy --require-approval never`
+  - 対象 stack の明示（誤デプロイ防止）
+- 受け入れ条件:
+  - main へのマージで自動デプロイされる
+  - 実行ログからどのコミットがどのスタックを更新したか追跡できる
+
+### CI-6（#8 の直後に追加）
+- タイトル案: `環境保護とデプロイガードレールを設定する`
+- 目的:
+  - 誤操作防止と監査性を確保する
+- スコープ:
+  - GitHub Environment 承認
+  - production への branch 制限
+  - デプロイ失敗時の通知（最低限）
+- 受け入れ条件:
+  - 保護ルール違反時に deploy が実行されない
+
+### CI-7（#11 と同時に追加）
+- タイトル案: `CI/CD Runbookを整備する`
+- 目的:
+  - OIDC 失敗、権限不足、bootstrap 不整合の復旧手順を明文化する
+- 受け入れ条件:
+  - `docs/` に運用手順があり、新規メンバーが再現できる
+
+## 改訂後の推奨実行順
+1. #1（既存）
+2. CI-1
+3. CI-2
+4. #2（既存）
+5. CI-3
+6. CI-4
+7. #3, #4, #5, #6（既存）
+8. CI-5
+9. #7（既存）
+10. #8（既存）
+11. CI-6
+12. #9, #10（既存）
+13. #11（既存）
+14. CI-7
+
+## 補足（現実的な例外）
+- 「bootstrap 以外は CI で実行」を厳密に守る場合でも、OIDC Role の初回作成は事前準備が必要
+- 可能な限り IaC 化するため、OIDC 関連の trust/policy JSON と設定値はリポジトリ管理し、変更履歴を残す

--- a/docs/plan/2026-02-09-mvp-issue-breakdown.md
+++ b/docs/plan/2026-02-09-mvp-issue-breakdown.md
@@ -1,0 +1,328 @@
+# MVP 実装計画 Issue 分解（RSS -> S3 -> Discussion）
+
+元計画:
+- `docs/plan/2026-02-09-mvp-rss-to-s3-to-github-discussion.md`
+- `docs/plan/2026-02-09-iac-cicd-bootstrap-and-github-actions.md`
+
+## 方針
+- まずは 1 feed の縦切りを完了させる
+- 依存関係を明示して、並行可能なものは並行で進める
+- 各 Issue は「Done が判定できる受け入れ条件」を持つ
+- デプロイは「ローカルで `cdk bootstrap` のみ」、それ以外は GitHub Actions（OIDC）で実行する
+
+## Issue 一覧
+
+### 1. 基本設計の固定（I/O, 命名, 設定スキーマ）
+- タイトル案: `MVPのI/O仕様と設定スキーマを確定する`
+- 目的:
+  - 実装着手前に、S3 key / schema v1 / SSM JSON / Secrets 名を固定する
+- スコープ:
+  - 正規化 schema v1 フィールド定義
+  - `item_id` 生成ルール（`sha256:` prefix を含む）
+  - S3 key 規約（raw/items/digest/feedback）
+  - SSM パラメータ JSON 形式
+  - Secrets キー名（GitHub token, HMAC secret）
+- 受け入れ条件:
+  - `docs/architecture.md` か `docs/plan/` に確定仕様が追記されている
+  - 実装側で参照するキー名が一意に決まっている
+- 依存:
+  - なし
+
+### CI-1. デプロイ戦略の固定（local bootstrap + CI deploy）
+- タイトル案: `デプロイ戦略を固定する（local bootstrap + CI deploy）`
+- 目的:
+  - ブランチ/環境ごとのデプロイルールを先に決め、IAM Trust 条件へ反映する
+- スコープ:
+  - 対象ブランチ（例: `main`）の定義
+  - GitHub Environment（例: `dev`, `prod`）の定義
+  - アカウント/リージョン、ロール命名規則の固定
+- 受け入れ条件:
+  - 方針が `docs/plan/` か `docs/architecture.md` に明記されている
+  - OIDC trust policy に必要な条件（`sub`）が定義済み
+- 依存:
+  - #1
+
+### CI-2. CDK bootstrap 手順の確定とテンプレート化
+- タイトル案: `CDK bootstrap方式を確定しテンプレート化する`
+- 目的:
+  - ローカル実行を bootstrap のみに限定し、再現可能にする
+- スコープ:
+  - `cdk bootstrap` コマンド/オプションの確定
+  - 必要に応じて bootstrap テンプレート管理（`--template`）
+  - Toolkit stack 名や qualifier の記録
+- 受け入れ条件:
+  - 新規環境で同手順により bootstrap 可能
+  - 手順がドキュメント化されている
+- 依存:
+  - CI-1
+
+### 2. CDK 土台（Stack 構成 + 最小 IAM）
+- タイトル案: `CDKでMVP基盤リソースを作成する`
+- 目的:
+  - MVP 実装のための最小 AWS リソースを定義する
+- スコープ:
+  - S3 バケット
+  - Step Functions State Machine
+  - Rust Lambda 用の関数定義（雛形）
+  - EventBridge Scheduler
+  - IAM 最小権限（S3 prefix 限定、SSM、Secrets）
+- 受け入れ条件:
+  - `cdk synth` が通る
+  - Lambda 実行ロールに不要権限が含まれていない
+- 依存:
+  - #1
+  - CI-2
+
+### CI-3. GitHub OIDC Provider/Role 準備
+- タイトル案: `GitHub OIDC Roleを準備する`
+- 目的:
+  - GitHub Actions から長期鍵なしで AWS AssumeRole できるようにする
+- スコープ:
+  - IAM OIDC Provider（`token.actions.githubusercontent.com`）
+  - デプロイ用 IAM Role（例: `GitHubActionsCdkDeployRole`）
+  - Trust policy 条件（`aud=sts.amazonaws.com`, `sub=repo:<org>/<repo>:...`）
+  - `cdk deploy` 実行に必要な権限ポリシー
+- 受け入れ条件:
+  - GitHub Actions 上で `aws sts get-caller-identity` が成功する
+  - 想定外ブランチから AssumeRole できない
+- 依存:
+  - CI-1
+  - CI-2
+
+### CI-4. GitHub Actions CI workflow（lint/test/synth）
+- タイトル案: `GitHub ActionsのCI workflowを実装する`
+- 目的:
+  - PR 時に品質ゲートを実行する
+- スコープ:
+  - `.github/workflows/ci.yml`
+  - `lint` / `test` / `cdk synth` 実行
+  - branch protection で必須チェック化できる状態
+- 受け入れ条件:
+  - PR で workflow が自動実行される
+  - 失敗時に merge できない設定にできる
+- 依存:
+  - #2
+  - CI-3
+
+### 3. Rust Lambda: fetch-sources（取得 + raw 保存）
+- タイトル案: `fetch-sources Lambdaを実装しraw RSSをS3保存する`
+- 目的:
+  - SSM の feed URL から RSS/Atom を取得し raw を保存する
+- スコープ:
+  - HTTP fetch（タイムアウト/リトライ）
+  - S3 key: `raw/v1/date=YYYY-MM-DD/feed=<escaped>/ts=<iso>.xml`
+  - 構造化ログ（`feed_url`, `stage`）
+- 受け入れ条件:
+  - 1 feed の raw XML が S3 に保存される
+  - 失敗時にエラーが握りつぶされず、原因がログで追跡できる
+- 依存:
+  - #1
+  - #2
+
+### 4. Rust Lambda: parse-normalize（パース + 正規化 + item 冪等保存）
+- タイトル案: `parse-normalize Lambdaを実装してitems v1を保存する`
+- 目的:
+  - raw から正規化 item を生成し、重複をスキップして保存する
+- スコープ:
+  - RSS 2.0 / Atom 最低限対応
+  - `item_id = sha256(canonical_url_or_link + title + published_at_iso)` 実装
+  - S3 `HeadObject` による重複スキップ
+  - S3 key: `items/v1/date=YYYY-MM-DD/<item_id>.json`
+- 受け入れ条件:
+  - 同一入力で同一 `item_id` が生成される
+  - 既存 item がある場合に保存をスキップできる
+- 依存:
+  - #1
+  - #2
+  - #3
+
+### 5. Rust Lambda: build-digest（digest 生成 + 保存）
+- タイトル案: `build-digest Lambdaでdigest.jsonとdiscussion.mdを生成する`
+- 目的:
+  - items から digest artifacts を生成して保存する
+- スコープ:
+  - アイテム集約/並び順
+  - markdown テンプレートの安定化
+  - S3 key:
+    - `digest/v1/date=YYYY-MM-DD/run=<iso>/digest.json`
+    - `digest/v1/date=YYYY-MM-DD/run=<iso>/discussion.md`
+  - `HeadObject` による重複スキップ
+- 受け入れ条件:
+  - digest.json と discussion.md が S3 に保存される
+  - 同一 run の再実行で重複作成しない
+- 依存:
+  - #1
+  - #2
+  - #4
+
+### 6. Rust Lambda: post-discussion（GitHub GraphQL 投稿）
+- タイトル案: `post-discussion LambdaでGitHub Discussionを投稿する`
+- 目的:
+  - digest markdown を GitHub Discussion に投稿する
+- スコープ:
+  - Secrets Manager からトークン取得
+  - GraphQL mutation 実装
+  - 投稿済みマーカー保存（`posted.json`）
+  - 本文要件（@mention + フォームリンク）
+- 受け入れ条件:
+  - 指定リポジトリに Discussion が投稿される
+  - 同一 run で再実行時は投稿済みマーカーによりスキップされる
+- 依存:
+  - #1
+  - #2
+  - #5
+
+### CI-5. GitHub Actions deploy workflow（OIDC + cdk deploy）
+- タイトル案: `GitHub Actionsのdeploy workflowを実装する`
+- 目的:
+  - `main` 反映時に CI から自動デプロイする
+- スコープ:
+  - `.github/workflows/deploy.yml`
+  - OIDC AssumeRole
+  - `cdk deploy --require-approval never`
+  - デプロイ対象 stack 明示
+- 受け入れ条件:
+  - `main` マージで deploy が実行される
+  - 実行ログからコミットと更新スタックを追跡できる
+- 依存:
+  - CI-3
+  - CI-4
+
+### 7. Step Functions オーケストレーション（MVP縦切り）
+- タイトル案: `State Machineを実装しMVPの縦切りを接続する`
+- 目的:
+  - `fetch -> parse -> build -> post` を実行可能にする
+- スコープ:
+  - 状態遷移定義
+  - retry/catch の基本方針
+  - 入出力（run_id など）の受け渡し
+- 受け入れ条件:
+  - 手動実行で end-to-end が完了する
+  - 失敗時にどの段階で落ちたか追跡できる
+- 依存:
+  - #2
+  - #3
+  - #4
+  - #5
+  - #6
+  - CI-5
+
+### 8. EventBridge Scheduler 接続（定期実行）
+- タイトル案: `SchedulerからState Machineを定期起動する`
+- 目的:
+  - 定期バッチとして自動実行できるようにする
+- スコープ:
+  - cron/rate 設定
+  - Scheduler 実行ロール
+  - 最低限の運用パラメータ化（有効化/無効化、時刻）
+- 受け入れ条件:
+  - スケジュール時刻に State Machine が起動する
+  - 実行ログから定期トリガーであることが確認できる
+- 依存:
+  - #7
+
+### CI-6. 環境保護とデプロイガードレール
+- タイトル案: `環境保護とデプロイガードレールを設定する`
+- 目的:
+  - 誤操作防止と監査性を確保する
+- スコープ:
+  - GitHub Environment 承認ルール
+  - production への branch 制限
+  - デプロイ失敗通知（最低限）
+- 受け入れ条件:
+  - 保護ルール違反時に deploy が実行されない
+- 依存:
+  - CI-5
+  - #8
+
+### 9. Rust Lambda(Function URL): form-handler（GET/POST + HMAC検証）
+- タイトル案: `form-handler Lambda(Function URL)を実装する`
+- 目的:
+  - フィードバックフォームの表示と保存を実現する
+- スコープ:
+  - GET: digest を読み取り動的 HTML 生成
+  - POST: HMAC + exp 検証、S3 保存
+  - S3 key: `feedback/v1/digest_id=<digest_id>/submitted_at=<iso>-<rand>.json`
+- 受け入れ条件:
+  - 正常な署名付き URL でフォーム表示/送信できる
+  - 期限切れ/改ざんトークンは 4xx で拒否される
+- 依存:
+  - #1
+  - #2
+  - #5
+
+### 10. テスト整備（fixtures + 純粋ロジック）
+- タイトル案: `RSS/Atom fixtureとユニットテストを整備する`
+- 目的:
+  - 主要ロジックの回帰防止
+- スコープ:
+  - fixture: RSS2.0 / Atom / 日付欠落 / entities
+  - 正規化ロジック単体テスト
+  - `item_id` 安定性テスト
+  - 冪等スキップ分岐テスト（AWS依存を薄く）
+- 受け入れ条件:
+  - `cargo test` が通る
+  - 主要ロジックの期待動作がテストで明文化されている
+- 依存:
+  - #4
+  - #5
+
+### 11. E2E 検証と運用ドキュメント
+- タイトル案: `MVPのE2E検証手順と運用Runbookを作成する`
+- 目的:
+  - デプロイ後の検証と運用を再現可能にする
+- スコープ:
+  - 実行手順（手動起動、定期実行確認）
+  - 失敗時の切り分けポイント（Lambda/State Machine/S3）
+  - 既知制約（1 feed 前提、PAT 運用など）
+- 受け入れ条件:
+  - 新規メンバーがドキュメントだけで検証を再実行できる
+  - DoD 1-7 の確認結果が記録される
+- 依存:
+  - #8
+  - #10
+
+### CI-7. CI/CD Runbook 整備
+- タイトル案: `CI/CD Runbookを整備する`
+- 目的:
+  - OIDC 失敗、権限不足、bootstrap 不整合の復旧手順を明文化する
+- スコープ:
+  - `docs/` に復旧手順を追加
+  - 監査時の確認観点（AssumeRole, deploy 履歴）を定義
+- 受け入れ条件:
+  - 新規メンバーが CI/CD トラブルを手順だけで再現・切り分けできる
+- 依存:
+  - #11
+  - CI-6
+
+## 実行順（推奨）
+1. #1
+2. CI-1
+3. CI-2
+4. #2
+5. CI-3
+6. CI-4
+7. #3, #4, #5, #6
+8. CI-5
+9. #7
+10. #8
+11. CI-6
+12. #9, #10
+13. #11
+14. CI-7
+
+## MVP 完了判定（チェックリスト）
+- [ ] 1 feed 取り込み
+- [ ] raw RSS を S3 保存
+- [ ] 正規化 items(v1) を S3 保存
+- [ ] digest(JSON/Markdown) を S3 保存
+- [ ] GitHub Discussion 投稿（@mention + form link）
+- [ ] 冪等スキップ（items/digest/discussion）
+- [ ] 将来の部分成功拡張を阻害しない設計
+
+## CI/CD 完了判定（チェックリスト）
+- [ ] ローカル操作が `cdk bootstrap` のみに限定されている
+- [ ] GitHub Actions OIDC で AWS AssumeRole できる
+- [ ] CI（lint/test/synth）が PR で必須化されている
+- [ ] deploy が GitHub Actions 経由で実行される
+- [ ] Environment 保護と監査導線がある

--- a/docs/plan/2026-02-09-mvp-rss-to-s3-to-github-discussion.md
+++ b/docs/plan/2026-02-09-mvp-rss-to-s3-to-github-discussion.md
@@ -1,0 +1,56 @@
+## Plan: MVP 実装計画（RSS→S3→Discussion）
+
+README と docs/architecture.md を起点に、このリポジトリはまだ骨組み段階（実コード/スタック未配置）なので、まず「最小の縦切り（1 feed→S3→Discussion）」を動かし、その後に複数 feed・部分成功・フィードバック収集（Function URL）へ拡張する順で進めます。コスト最小・再実行可能性（S3 に原本/正規化を保存）・冪等性（S3 HeadObject）・設定は SSM/Secrets を前提にします。
+
+### MVP の定義（縦切り）
+- 入力: SSM から取得する feed URL（まずは 1 件）
+- 出力: S3 に raw RSS / normalized items / digest artifacts を保存し、GitHub Discussion を 1 件作成する
+- 実行: EventBridge Scheduler → Step Functions → 複数 Lambda（Rust）
+
+### 受け入れ条件（Definition of Done）
+1. 1 feed を取り込める（RSS2.0 または Atom のどちらかは最低限）
+2. raw RSS が S3 に保存される（再実行・調査用）
+3. 正規化 item がスキーマ v1 で S3 に保存される（`item_id` は決定的）
+4. digest（JSON + Markdown）が S3 に保存される
+5. GitHub Discussion が安定フォーマットで投稿され、@mention とフォームリンクを含む
+6. 冪等: 同じ run を再実行しても items/digest/discussion が重複作成されない（S3 HeadObject でスキップ）
+7. 1 feed の失敗が StateMachine 全体を失敗させない設計に拡張可能（MVPでは単一 feed でも例外設計は仕込む）
+
+### Steps
+1. README.md と docs/architecture.md を要件化し、MVP の I/O（S3 keys / 正規化スキーマv1 / Discussion フォーマット）を確定する
+2. CDK(TypeScript) の app/stack 構成を作り、S3/SSM/Secrets/Step Functions/Lambda を最小権限で定義する
+3. Rust Lambda: `fetch-sources`（HTTP fetch + retry）→ raw を S3 に保存
+4. Rust Lambda: `parse-normalize`（S3 から raw を読んで RSS/Atom パース）→ 正規化(item_id 生成)→ items を S3 に保存（HeadObject で重複スキップ）
+5. Rust Lambda: `build-digest`（items 集約/フィルタ/順序）→ digest.json + discussion.md を生成して S3 に保存
+6. Rust Lambda: `post-discussion`（GitHub GraphQL）で Discussion 作成（安定フォーマット、@mention、フォームリンクを含む）
+7. Rust Lambda(Function URL): `form-handler` を実装（GET: HTML生成 / POST: HMAC+exp 検証→S3 保存）
+8. Step Functions を「部分成功」前提でオーケストレーションし、EventBridge Scheduler で定期起動にする
+
+### 決めること（先に決めると詰まらない）
+- SSM パラメータ名と JSON 形式（例: feeds 配列、対象 repo、category_id、@mention、時間窓、フィルタ条件）
+- Secrets の名前/キー（GitHub token、フォーム署名用 HMAC secret）
+- `digest_id` の定義（例: `run_id` と同一の ISO 文字列）
+- Discussion のカテゴリ（category_id の取得方法・運用手順）
+- items の日付パーティション基準（推奨: fetched_at の日付で `items/v1/date=YYYY-MM-DD/`）
+
+### 冪等性（MVPでの具体）
+- raw: 常に保存（`raw/v1/.../ts=<iso>.xml`）
+- items: `items/v1/date=.../<item_id>.json` を `HeadObject` で存在確認し、あればスキップ
+- digest: `digest/v1/date=.../run=<run_id>/digest.json` 等を `HeadObject` で存在確認し、あればスキップ
+- discussion: 投稿済みマーカーを S3 に保存して `HeadObject` でスキップ（例: `digest/v1/.../run=<run_id>/posted.json` に Discussion URL/ID を記録）
+
+### 部分成功（拡張を見据えた前提）
+- 将来の複数 feed は Step Functions の Map で並列化し、feed 単位で Catch して失敗を集約ログに残す
+- build-digest は「成功した feed の items」だけで digest を作れる設計にする
+
+### テスト観点（最小）
+- 正規化: RSS/Atom の fixture を用意（published 欠落、リンク揺れ、エンティティ等）
+- `item_id` の安定性: 同一入力→同一 ID、URL/title/date の変化→異なる ID
+- 冪等スキップ: S3 既存想定の分岐（AWS 呼び出し部は薄く、ドメインロジックを純粋関数でテスト）
+
+### Further Considerations
+1. 初期スコープ: 1 feed 固定（SSM）で縦切り→複数 feed は Map state で拡張
+2. GitHub 認証: まず PAT、後で GitHub App へ移行（Secrets の形を揃える）
+3. 冪等性粒度: raw は常に保存、items/digest/discussion は HeadObject でスキップ（Discussion は S3 に投稿済みマーカーを残す）
+4. セキュリティ: secrets をログに出さない、Function URL は HMAC+exp を必須にし、期限切れ/改竄は 4xx
+5. コスト: API Gateway を避け Function URL 優先、S3 は lifecycle で raw の保持期間を調整（必要なら）


### PR DESCRIPTION
## 概要
MVP実装計画を具体化し、IaC/CICDの初期セットアップと実装着手用のIssue分割計画を追加しました。

## 変更内容
- `docs/plan/2026-02-09-mvp-rss-to-s3-to-github-discussion.md` を更新し、MVP実装計画を明確化
- `docs/plan/2026-02-09-iac-cicd-bootstrap-and-github-actions.md` を追加し、CDK/Rust/Step Functions前提のIaC/CICDブートストラップ方針を整理
- `docs/plan/2026-02-09-mvp-issue-breakdown.md` を追加し、MVPを実装単位のIssueに分解
- `AGENTS.md` を更新

## 目的
- MVP実装の開始前に、作業順序・責務分割・運用導線を文書化して開発を進めやすくするため
